### PR TITLE
Refactor projects data and layout

### DIFF
--- a/src/app/components/ProjectShowcase.tsx
+++ b/src/app/components/ProjectShowcase.tsx
@@ -21,83 +21,86 @@ export default function ProjectShowcase({
   description,
   images,
   tools,
-  linkToProject
+  linkToProject,
 }: ProjectShowcaseProps) {
   const [activeImage, setActiveImage] = useState(0);
 
   return (
     <div className="max-w-4xl mx-auto my-10 p-6 bg-white dark:bg-gray-800 rounded-lg shadow-md">
-      <h2 className="text-2xl font-bold mb-4">{title}</h2>
+      <h2 className="text-2xl font-bold mb-6">{title}</h2>
+      <div className="grid md:grid-cols-2 gap-8 items-start">
+        {/* Textual content */}
+        <div>
+          {description && (
+            <p className="text-gray-700 dark:text-gray-300 mb-4">{description}</p>
+          )}
 
-      {description && (
-        <p className="text-gray-700 dark:text-gray-300 mb-4">{description}</p>
-      )}
+          {tools && tools.length > 0 && (
+            <div className="mt-4">
+              <h3 className="text-lg font-semibold mb-2">Tools Used:</h3>
+              <ul className="list-disc list-inside text-gray-700 dark:text-gray-300 space-y-1">
+                {tools.map((tool, index) => (
+                  <li key={index}>{tool}</li>
+                ))}
+              </ul>
+            </div>
+          )}
 
-      {/* Thumbnails (only if more than 1 image) */}
-      {images.length > 1 && (
-        <div className="flex gap-6 mb-6">
-          {images.map((img, index) => (
-            <button
-              key={index}
-              onClick={() => setActiveImage(index)}
-              className={`w-20 h-20 rounded-lg overflow-hidden border ${
-                activeImage === index ? "border-blue-500" : "border-gray-300"
-              }`}
-            >
-              <Image
-                src={img.src}
-                alt={img.alt}
-                width={80}
-                height={80}
-                className="object-contain w-full h-full"
-              />
-            </button>
-          ))}
+          {linkToProject && (
+            <div className="mt-6">
+              <Link
+                href={linkToProject}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
+              >
+                Visit Project →
+              </Link>
+            </div>
+          )}
         </div>
-      )}
 
-      {/* Main image display */}
-      <div
-        className={`mb-6 mx-auto w-full ${
-          images.length === 1
-            ? "max-w-[480px] sm:max-w-[560px] md:max-w-[640px]"
-            : "max-w-[320px] sm:max-w-[360px] md:max-w-[400px]"
-        }`}
-      >
-        <Image
-          src={images[activeImage].src}
-          alt={images[activeImage].alt}
-          width={360}
-          height={640}
-          className="rounded-lg shadow-lg w-full h-auto object-contain"
-        />
-      </div>
+        {/* Image section */}
+        <div className="flex flex-col items-center">
+          {images.length > 1 && (
+            <div className="flex gap-6 mb-6">
+              {images.map((img, index) => (
+                <button
+                  key={index}
+                  onClick={() => setActiveImage(index)}
+                  className={`w-20 h-20 rounded-lg overflow-hidden border ${
+                    activeImage === index ? "border-blue-500" : "border-gray-300"
+                  }`}
+                >
+                  <Image
+                    src={img.src}
+                    alt={img.alt}
+                    width={80}
+                    height={80}
+                    className="object-contain w-full h-full"
+                  />
+                </button>
+              ))}
+            </div>
+          )}
 
-      {/* Tools list */}
-      {tools && tools.length > 0 && (
-        <div className="mt-4">
-          <h3 className="text-lg font-semibold mb-2">Tools Used:</h3>
-          <ul className="list-disc list-inside text-gray-700 dark:text-gray-300">
-            {tools.map((tool, index) => (
-              <li key={index}>{tool}</li>
-            ))}
-          </ul>
-        </div>
-      )}
-
-      {/* Link to project */}
-      {linkToProject && (
-        <div className="mt-6">
-          <Link
-            href={linkToProject}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
+          <div
+            className={`mx-auto w-full ${
+              images.length === 1
+                ? "max-w-[480px] sm:max-w-[560px] md:max-w-[640px]"
+                : "max-w-[320px] sm:max-w-[360px] md:max-w-[400px]"
+            }`}
           >
-            Visit Project →
-          </Link>
+            <Image
+              src={images[activeImage].src}
+              alt={images[activeImage].alt}
+              width={360}
+              height={640}
+              className="rounded-lg shadow-lg w-full h-auto object-contain transform hover:scale-105 transition"
+            />
+          </div>
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/src/app/data/projects.ts
+++ b/src/app/data/projects.ts
@@ -1,0 +1,41 @@
+export type Project = {
+  title: string;
+  description: string;
+  images: { src: string; alt: string }[];
+  tools: string[];
+  linkToProject?: string;
+};
+
+export const projects: Project[] = [
+  {
+    title: "ContractorWorks",
+    description:
+      "ContractorWorks is a mobile first workforce management platform that helps businesses oversee contractors, job sites, and invoices entirely from their phone. The app includes role-based access for bosses and contractors, secure login and authentication, a boss dashboard for tracking project status, timesheets, and contractor information, and a dedicated contractor view for submitting work logs and tracking assignments. Designed for real-world use, it supports real-time updates, offline accessibility, and mobile optimization—reducing paperwork and improving efficiency in the field.",
+    images: [
+      { src: "/images/projectimgs/simLongin.png", alt: "Login Screen" },
+      { src: "/images/projectimgs/simBossDash.png", alt: "Boss Dashboard" },
+      { src: "/images/projectimgs/simContractorView.png", alt: "Contractor View" }
+    ],
+    tools: ["Flutter", "Firebase"],
+  },
+  {
+    title: "Jam Circle",
+    description:
+      "Jam Circle is a social music platform that reimagines how people discover and connect through music. Instead of waiting for Spotify Wrapped, users can see and share their top artists and albums year-round. The app features live music rooms with synced playback, personalized top 10 lists, music ratings and reviews, and a social feed with leaderboards to highlight trending activity among friends. Built collaboratively in a fast-paced team environment, Jam Circle emphasizes real-time interaction, user-driven discovery, and a more connected music experience.",
+    images: [
+      { src: "/images/projectimgs/jamCircle/jamcircle.png", alt: "Full Admin Dashboard" }
+    ],
+    tools: ["Django", "PostgreSQL", "Spotify API", "Agora", "React", "Postman", "GitHub"],
+    linkToProject: "https://github.com/Namebrand71/JamCircleDevs",
+  },
+  {
+    title: "Herding Cat (PADEN Bot)",
+    description:
+      "A productivity Slackbot designed for software teams, Herding Cat automates daily standups, pull request tracking, Jira issue updates, and release timelines—all inside Slack. Created in partnership with cybersecurity company Brinqa, the bot was built to streamline task management for engineering leads juggling multiple teams.The bot simplifies team operations by organizing updates, surfacing high-priority tasks, and reducing the need for manual tracking. It features custom filters, visual timelines, automated schedulers, and a playful touch through randomized icebreakers—all aimed at helping teams stay aligned and focused.",
+    images: [
+      { src: "/images/projectimgs/Brinqa_Herding_Cats-Poster1.jpg", alt: "BrinqaPoster" }
+    ],
+    tools: ["TypeScript", "SQLite", "Docker", "Slack API", "Jira API", "Bitbucket", "Axios", "Cron"],
+    linkToProject: "https://github.com/pomeloFellow/Paden-SlackBot",
+  }
+];

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,44 +1,13 @@
 import ProjectShowcase from "../components/ProjectShowcase";
+import { projects } from "../data/projects";
 
 export default function ProjectsPage() {
   return (
-    <main className="p-20 max-w-5xl mx-auto">
+    <main className="px-6 py-20 max-w-5xl mx-auto">
       <h1 className="text-4xl font-bold mb-8">Projects</h1>
-
-      <ProjectShowcase
-        title="ContractorWorks"
-        description="ContractorWorks is a mobile first workforce management platform that helps businesses oversee contractors, job sites, and invoices entirely from their phone. The app includes role-based access for bosses and contractors, secure login and authentication, a boss dashboard for tracking project status, timesheets, and contractor information, and a dedicated contractor view for submitting work logs and tracking assignments.
-Designed for real-world use, it supports real-time updates, offline accessibility, and mobile optimization—reducing paperwork and improving efficiency in the field.
-"
-        images={[
-          { src: "/images/projectimgs/simLongin.png", alt: "Login Screen" },
-          { src: "/images/projectimgs/simBossDash.png", alt: "Boss Dashboard" },
-          { src: "/images/projectimgs/simContractorView.png", alt: "Contractor View" },
-        ]}
-        tools={["Flutter", "Firebase"]}
-        
-      />
-
-      <ProjectShowcase
-        title="Jam Circle"
-        description="Jam Circle is a social music platform that reimagines how people discover and connect through music. Instead of waiting for Spotify Wrapped, users can see and share their top artists and albums year-round. The app features live music rooms with synced playback, personalized top 10 lists, music ratings and reviews, and a social feed with leaderboards to highlight trending activity among friends.
-Built collaboratively in a fast-paced team environment, Jam Circle emphasizes real-time interaction, user-driven discovery, and a more connected music experience."
-        images={[
-          { src: "/images/projectimgs/jamCircle/jamcircle.png", alt: "Full Admin Dashboard" },
-        ]}
-        tools={["Django", "PostgreSQL", "Spotify API", "Agora", "React", "Postman", "GitHub"]}
-        linkToProject="https://github.com/Namebrand71/JamCircleDevs"
-      />
-
-      <ProjectShowcase
-        title="Herding Cat (PADEN Bot)"
-        description="A productivity Slackbot designed for software teams, Herding Cat automates daily standups, pull request tracking, Jira issue updates, and release timelines—all inside Slack. Created in partnership with cybersecurity company Brinqa, the bot was built to streamline task management for engineering leads juggling multiple teams.The bot simplifies team operations by organizing updates, surfacing high-priority tasks, and reducing the need for manual tracking. It features custom filters, visual timelines, automated schedulers, and a playful touch through randomized icebreakers—all aimed at helping teams stay aligned and focused."
-        images={[
-          { src: "/images/projectimgs/Brinqa_Herding_Cats-Poster1.jpg", alt: "BrinqaPoster" },
-        ]}
-        tools={["TypeScript", "SQLite", "Docker","Slack API", "Jira API", "Bitbucket", "Axios", "Cron"]}
-        linkToProject="https://github.com/pomeloFellow/Paden-SlackBot"
-      />
+      {projects.map((project) => (
+        <ProjectShowcase key={project.title} {...project} />
+      ))}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- organize project details in a new `projects` data file
- simplify `/projects` route by iterating over the data
- redesign `ProjectShowcase` layout with a two‑column grid and responsive image interactions

## Testing
- `npm run lint` *(fails: next not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68439bdd5838832693e51c49044da4cc